### PR TITLE
update the default flink download url to flink 0.10.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ More details on Flink and how it is being used in the industry today available h
 
 The Ambari service lets you easily install/compile Flink on HDP 2.3
 - Features:
-  - By default, downloads prebuilt package of Flink 0.9.1, but also gives option to build the latest Flink from source instead
+  - By default, downloads prebuilt package of Flink 0.10.1, but also gives option to build the latest Flink from source instead
   - Exposes flink-conf.yaml in Ambari UI 
 
 Author: [Ali Bajwa](https://github.com/abajwa-hw)

--- a/configuration/flink-ambari-config.xml
+++ b/configuration/flink-ambari-config.xml
@@ -63,7 +63,7 @@
 
   <property>
     <name>flink_download_url</name>
-    <value>http://www.us.apache.org/dist/flink/flink-0.10.0/flink-0.10.0-bin-hadoop27-scala_2.10.tgz</value>
+    <value>http://www.us.apache.org/dist/flink/flink-0.10.1/flink-0.10.1-bin-hadoop27-scala_2.10.tgz</value>
     <description>Snapshot download location. Downloaded when setup_prebuilt is true</description>
   </property>   
 


### PR DESCRIPTION
Hi, just a small update for the default flink download url and 
adjust the Readme accordingly
