### PR TITLE
Flink and Ambari update

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Apache Flink is an open source platform for distributed stream and batch data pr
 More details on Flink and how it is being used in the industry today available here: [http://flink-forward.org/?post_type=session](http://flink-forward.org/?post_type=session)
 
 
-The Ambari service lets you easily install/compile Flink on HDP 2.5
+The Ambari service lets you easily install/compile Flink on HDP 2.5.3
 - Features:
-  - By default, downloads prebuilt package of Flink 1.0, but also gives option to build the latest Flink from source instead
+  - By default, downloads prebuilt package of Flink 1.2, but also gives option to build the latest Flink from source instead
   - Exposes flink-conf.yaml in Ambari UI 
 
 Limitations:
@@ -15,7 +15,7 @@ Limitations:
 
 Author: [Ali Bajwa](https://github.com/abajwa-hw)
 - Thanks to [Davide Vergari](https://github.com/dvergari) for enhancing to run in clustered env
-
+- Thanks to [Ben Harris](https://github.com/jamesbenharris) for updating libraries to work with HDP 2.5.3
 #### Setup
 
 - Download HDP 2.5 sandbox VM image (Sandbox_HDP_2.5_1_VMware.ova) from [Hortonworks website](http://hortonworks.com/products/hortonworks-sandbox/)

--- a/configuration/flink-ambari-config.xml
+++ b/configuration/flink-ambari-config.xml
@@ -10,7 +10,7 @@
     <value>/opt/flink</value>
     <description>Location to install Flink</description>
   </property> 
-  
+
   <property>
     <name>flink_numcontainers</name>
     <value>1</value>
@@ -69,7 +69,7 @@
 
   <property>
     <name>flink_download_url</name>
-    <value>http://www.us.apache.org/dist/flink/flink-1.1.2/flink-1.1.2-bin-hadoop27-scala_2.11.tgz</value>
+    <value>hhttp://www.us.apache.org/dist/flink/flink-1.2.0/flink-1.2.0-bin-hadoop2-scala_2.11.tgz</value>
     <description>Snapshot download location. Downloaded when setup_prebuilt is true</description>
   </property>   
 

--- a/configuration/flink-env.xml
+++ b/configuration/flink-env.xml
@@ -113,7 +113,9 @@ state.backend: jobmanager
 # via keys 'fs.hdfs.hdfsdefault' and 'fs.hdfs.hdfssite'.
 #
 # fs.hdfs.hadoopconf: /path/to/hadoop/conf/
-
+env.java.home: /usr/jdk64/jdk1.8.0_77/jre
+taskmanager.memory.fraction: 0.6
+env.java.opts: -XX:+UseG1GC
   </value>
   <description>Template for flink-conf.yaml</description>
   

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -6,7 +6,7 @@
             <name>FLINK</name>
             <displayName>Flink</displayName>
             <comment>Apache Flink is a streaming dataflow engine that provides data distribution, communication, and fault tolerance for distributed computations over data streams.</comment>
-            <version>1.0</version>
+            <version>1.2</version>
             <components>
                 <component>
                   <name>FLINK_MASTER</name>

--- a/package/scripts/flink.py
+++ b/package/scripts/flink.py
@@ -43,8 +43,8 @@ class Master(Script):
       #Fetch and unzip snapshot build, if no cached flink tar package exists on Ambari server node
       if not os.path.exists(params.temp_file):
         Execute('wget '+params.flink_download_url+' -O '+params.temp_file+' -a '  + params.flink_log_file, user=params.flink_user)
-      Execute('tar -zxvf '+params.temp_file+' -C ' + params.flink_install_dir + ' >> ' + params.flink_log_file, user=params.flink_user)
-      Execute('mv '+params.flink_install_dir+'/*/* ' + params.flink_install_dir, user=params.flink_user)
+        Execute('tar -zxvf '+params.temp_file+' -C ' + params.flink_install_dir + ' >> ' + params.flink_log_file, user=params.flink_user)
+        Execute('mv '+params.flink_install_dir+'/*/* ' + params.flink_install_dir, user=params.flink_user)
                 
       #update the configs specified by user
       self.configure(env, True)


### PR DESCRIPTION
- Updated to Flink 1.2
- Verified Flink 1.2 Service ran on Ambari 2.5.3
- Updated Service version to 1.2 in metainfo
- Added JAVA_HOME, Garbage Collection settings
- Updated Readme to reflect the above changes