### PR TITLE
Add support for HDP 2.6.5, and update to latest flink version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Apache Flink is an open source platform for distributed stream and batch data pr
 More details on Flink and how it is being used in the industry today available here: [http://flink-forward.org/?post_type=session](http://flink-forward.org/?post_type=session)
 
 
-The Ambari service lets you easily install/compile Flink on HDP 2.5.3
+The Ambari service lets you easily install/compile Flink on HDP 2.6.5
 - Features:
-  - By default, downloads prebuilt package of Flink 1.2, but also gives option to build the latest Flink from source instead
+  - By default, downloads prebuilt package of Flink 1.8.1, but also gives option to build the latest Flink from source instead
   - Exposes flink-conf.yaml in Ambari UI 
 
 Limitations:
@@ -16,10 +16,11 @@ Limitations:
 Author: [Ali Bajwa](https://github.com/abajwa-hw)
 - Thanks to [Davide Vergari](https://github.com/dvergari) for enhancing to run in clustered env
 - Thanks to [Ben Harris](https://github.com/jamesbenharris) for updating libraries to work with HDP 2.5.3
+- Thanks to [Anand Subramanian](https://github.com/anandsubbu) for updating libraries to work with HDP 2.6.5 and flink version 1.8.1
 #### Setup
 
-- Download HDP 2.5 sandbox VM image (Sandbox_HDP_2.5_1_VMware.ova) from [Hortonworks website](http://hortonworks.com/products/hortonworks-sandbox/)
-- Import Sandbox_HDP_2.3_1_VMware.ova into VMWare and set the VM memory size to 8GB
+- Download HDP 2.6 sandbox VM image (HDP_2.6.5_virtualbox_180626.ova) from [Cloudera website](https://www.cloudera.com/downloads/hortonworks-sandbox/hdp.html)
+- Import HDP_2.6.5_virtualbox_180626.ova into VMWare and set the VM memory size to 8GB
 - Now start the VM
 - After it boots up, find the IP address of the VM and add an entry into your machines hosts file. For example:
 ```
@@ -92,6 +93,7 @@ curl -u admin:$PASSWORD -i -H 'X-Requested-By: ambari' -X PUT -d '{"RequestInfo"
 ```
 su flink
 export HADOOP_CONF_DIR=/etc/hadoop/conf
+export HADOOP_CLASSPATH=`hadoop classpath`
 cd /opt/flink
 ./bin/flink run --jobmanager yarn-cluster -yn 1 -ytm 768 -yjm 768 ./examples/batch/WordCount.jar
 ```
@@ -123,21 +125,25 @@ More details on Flink and how it is being used in the industry today available h
   - Stop the service via Ambari
   - Unregister the service
   
-    ```
+```
 export SERVICE=FLINK
 export PASSWORD=admin
 export AMBARI_HOST=localhost
-#detect name of cluster
+
+# detect name of cluster
 output=`curl -u admin:$PASSWORD -i -H 'X-Requested-By: ambari'  http://$AMBARI_HOST:8080/api/v1/clusters`
 CLUSTER=`echo $output | sed -n 's/.*"cluster_name" : "\([^\"]*\)".*/\1/p'`
 
 curl -u admin:$PASSWORD -i -H 'X-Requested-By: ambari' -X DELETE http://$AMBARI_HOST:8080/api/v1/clusters/$CLUSTER/services/$SERVICE
+```
 
-#if above errors out, run below first to fully stop the service
-#curl -u admin:$PASSWORD -i -H 'X-Requested-By: ambari' -X PUT -d '{"RequestInfo": {"context" :"Stop $SERVICE via REST"}, "Body": {"ServiceInfo": {"state": "INSTALLED"}}}' http://$AMBARI_HOST:8080/api/v1/clusters/$CLUSTER/services/$SERVICE
-    ```
-   - Remove artifacts
-    ```
-    rm -rf /opt/flink*
-    rm /tmp/flink.tgz
-    ```   
+If above errors out, run below first to fully stop the service
+```
+curl -u admin:$PASSWORD -i -H 'X-Requested-By: ambari' -X PUT -d '{"RequestInfo": {"context" :"Stop $SERVICE via REST"}, "Body": {"ServiceInfo": {"state": "INSTALLED"}}}' http://$AMBARI_HOST:8080/api/v1/clusters/$CLUSTER/services/$SERVICE
+```
+
+- Remove artifacts
+```
+rm -rf /opt/flink*
+rm /tmp/flink.tgz
+```

--- a/configuration/flink-ambari-config.xml
+++ b/configuration/flink-ambari-config.xml
@@ -69,11 +69,13 @@
 
   <property>
     <name>flink_download_url</name>
-    <value>hhttp://www.us.apache.org/dist/flink/flink-1.2.0/flink-1.2.0-bin-hadoop2-scala_2.11.tgz</value>
+    <value>http://apachemirror.wuchna.com/flink/flink-1.8.1/flink-1.8.1-bin-scala_2.11.tgz</value>
     <description>Snapshot download location. Downloaded when setup_prebuilt is true</description>
-  </property>   
+  </property>
 
-    
-  
-    
-</configuration>  
+  <property>
+    <name>flink_hadoop_shaded_jar</name>
+    <value>https://repo.maven.apache.org/maven2/org/apache/flink/flink-shaded-hadoop-2-uber/2.6.5-7.0/flink-shaded-hadoop-2-uber-2.6.5-7.0.jar</value>
+    <description>Flink shaded hadoop jar download location. Downloaded when setup_prebuilt is true</description>
+  </property>
+</configuration>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -6,7 +6,7 @@
             <name>FLINK</name>
             <displayName>Flink</displayName>
             <comment>Apache Flink is a streaming dataflow engine that provides data distribution, communication, and fault tolerance for distributed computations over data streams.</comment>
-            <version>1.2</version>
+            <version>1.8.1</version>
             <components>
                 <component>
                   <name>FLINK_MASTER</name>

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -25,7 +25,7 @@ flink_streaming = config['configurations']['flink-ambari-config']['flink_streami
 
 hadoop_conf_dir = config['configurations']['flink-ambari-config']['hadoop_conf_dir']
 flink_download_url = config['configurations']['flink-ambari-config']['flink_download_url']
- 
+flink_hadoop_shaded_jar_url = config['configurations']['flink-ambari-config']['flink_hadoop_shaded_jar']
 
 conf_dir=''
 bin_dir=''


### PR DESCRIPTION
Please review the changes.

**Testing Done**

* On an existing HDP 2.6.5 multi-node cluster, followed the steps in the README to copy and install the Flink service via Ambari
* Verified that the Flink service starts up fine.
* Ran the word count sample program and verified it completed successfully.

Note:
- While the word count sample ran fine, I could see however that the completed jobs are not being listed in the Flink UI under the history. I could see that YARN RM UI showing the list of completed jobs too.