### PR TITLE
claim dependency on yarn to be functional

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -35,6 +35,10 @@
 	        	<config-type>flink-ambari-config</config-type>      	   
       	    </configuration-dependencies>
             <restartRequiredAfterChange>false</restartRequiredAfterChange>
+
+            <requiredServices>
+              <service>YARN</service>
+            </requiredServices>
         </service>
     </services>
 </metainfo>

--- a/role_command_order.json
+++ b/role_command_order.json
@@ -1,0 +1,6 @@
+{
+  "general_deps" : {
+    "_comment" : "dependencies for flink",
+    "FLINK_MASTER-START" : ["RESOURCEMANAGER-START"]
+  }
+}


### PR DESCRIPTION
apparently, flink should be started after yarn, or, things may be messed up.